### PR TITLE
Rename LocalVideoCaptuerer to LocalVideoCapturer

### DIFF
--- a/src/w69b/localvideocapturer.js
+++ b/src/w69b/localvideocapturer.js
@@ -24,23 +24,23 @@ goog.scope(function() {
     this.backContext_ = /** @type {CanvasRenderingContext2D} */ (
       this.backCanvas_.getContext('2d'));
   };
-  var LocalVideoCaptuerer = w69b.LocalVideoCapturer;
-  goog.inherits(LocalVideoCaptuerer, goog.Disposable);
-  var pro = LocalVideoCaptuerer.prototype;
+  var LocalVideoCapturer = w69b.LocalVideoCapturer;
+  goog.inherits(LocalVideoCapturer, goog.Disposable);
+  var pro = LocalVideoCapturer.prototype;
 
   /**
    * Alias to getUserMedia functions.
    * @type {Function}
    */
-  LocalVideoCaptuerer.getMedia = (
+  LocalVideoCapturer.getMedia = (
     navigator['getUserMedia'] ||
       navigator['webkitGetUserMedia'] ||
       navigator['mozGetUserMedia'] ||
       navigator['msGetUserMedia']);
 
-  if (LocalVideoCaptuerer.getMedia)
-    LocalVideoCaptuerer.getMedia =
-      LocalVideoCaptuerer.getMedia.bind(navigator);
+  if (LocalVideoCapturer.getMedia)
+    LocalVideoCapturer.getMedia =
+      LocalVideoCapturer.getMedia.bind(navigator);
 
   /**
    * Canvas uses to call getImageData on.
@@ -185,7 +185,7 @@ goog.scope(function() {
           break;
         }
       }
-      LocalVideoCaptuerer.getMedia({'video': constraint},
+      LocalVideoCapturer.getMedia({'video': constraint},
         self.onGetMediaSuccess.bind(self),
         self.onGetMediaError.bind(self));
     }


### PR DESCRIPTION
I'm working on the assumption that `LocalVideoCaptuerer` is a typo'd version of the name `LocalVideoCapturer`. Renaming the variable makes it easier to search the codebase. If the name was intention with 'Captuerer' then ignore this pull request.